### PR TITLE
API tests

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -1,0 +1,25 @@
+name: Publish to nuget
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - src/version.props
+      - .github/workflows/nuget.yml
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Publish NuGet
+        uses: brandedoutcast/publish-nuget@v2.5.5
+        with:
+          PROJECT_FILE_PATH: src/Likvido.Test.Api/Likvido.Test.Api.csproj
+          VERSION_FILE_PATH: src/version.props
+          PACKAGE_NAME: Likvido.Test.Api
+          VERSION_REGEX: <Version>(.*)<\/Version>
+          NUGET_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -31,12 +31,44 @@ public class MyTestFixture : ConfigurableTestFixture<Startup, MyDesignDbContext,
     {
     }
 
-    public HttpClient Client => HttpClientFactory.HttpClient;
     // Get configured clients by name:
-    public override HttpClient AuthClient => HttpClientFactory.GetNamedHttpClient("Auth");
+    public HttpClient AuthClient => HttpClientFactory.GetNamedHttpClient("Auth");
 
     // Add mocks to overwrite services.
     public Mock<IMyService> MyService { get; } = new();
+}
+```
+
+Add db context fixture and configuration.
+```c#
+public class MySqliteContextFixture : SqliteContextFixture<PayablesContext, ApplicationDbContext>
+{
+    private ITestDataHelper? _testDataHelper;
+
+    protected override ITestDataHelper GetTestDataHelper() =>
+        _testDataHelper ??= new MyDbSqliteTestDataHelper(() => DesignContext, Quote);
+}
+
+public class MyDbSqliteTestDataHelper : BaseTestDataHelper<MyDesignContext>
+{
+    public MyDbSqliteTestDataHelper(
+        Func<MyDesignContext> context,
+        Func<string, string> quote) : base(context, quote)
+    {
+    }
+
+    public override async Task GenerateTestDataAsync()
+    {
+        // Add test data to Context.
+    }
+
+    public override string[] GetCleanupTables()
+    {
+        return new[]
+        {
+            // Names of tables to cleanup after test execution.
+        };
+    }
 }
 ```
 
@@ -75,4 +107,4 @@ public class MyControllerTests : TestsBase<MyTestFixture>
 
 ## Note
 
-[More on integration tests.](https://docs.microsoft.com/en-us/aspnet/core/test/integration-tests?view=aspnetcore-5.0)
+[More on integration tests in ASP.NET Core](https://docs.microsoft.com/en-us/aspnet/core/test/integration-tests?view=aspnetcore-5.0)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 # Likvido.Test.Api
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,78 @@
 # Likvido.Test.Api
 
+Likvido.Test.Api adds support for ASP.NET Core integration tests using a test web host and an in-memory test server.
+
+Integration tests ensure that an app's components function correctly at a level that includes the app's supporting infrastructure, such as the database and network. 
+
+## API app prerequisites
+* `TargetFramework net5.0`
+* `Microsoft.EntityFrameworkCore`
+
+## How to add integration tets
+
+Create a new test project and reference packages:
+* `Likvido.Test.Api`
+* `xunit`
+
+Add a text fixture interited from `ConfigurableTestFixture`.
+```c#
+public class MyTestFixture : ConfigurableTestFixture<Startup, MyDesignDbContext, MyRuntimeDbContext>
+{
+    public MyTestFixture(DatabaseFixture<MyDesignDbContext, MyRuntimeDbContext> databaseFixture)
+        : base(new FixtureOptions<MyDesignDbContext, MyRuntimeDbContext>
+        {
+            DatabaseFixture = databaseFixture,
+            ConfigureNamedHttpClients = new()
+            {
+                // Configure clients with different settings.
+                ["Auth"] = (httpClient, configuration) => httpClient.DefaultRequestHeaders.Add("ApiKey", configuration["ApiKey"])
+            };
+        })
+    {
+    }
+
+    public HttpClient Client => HttpClientFactory.HttpClient;
+    // Get configured clients by name:
+    public override HttpClient AuthClient => HttpClientFactory.GetNamedHttpClient("Auth");
+
+    // Add mocks to overwrite services.
+    public Mock<IMyService> MyService { get; } = new();
+}
+```
+
+Add an xunit collection. This will share test fixture between tests.
+```c#
+[CollectionDefinition(Name)]
+public class MyTestFixtureCollection : ICollectionFixture<MyTestFixture>
+{
+    public const string Name = nameof(MyTestFixtureCollection);
+}
+```
+
+Add controller tests and a collection attribute.
+
+```c#
+[Collection(MyTestFixtureCollection.Name)]
+public class MyControllerTests : TestsBase<MyTestFixture>
+{
+  [Fact]
+  public async Task Should_Get_Something()
+  {
+      // Db context is awailable via Fixture.Context. Add extensions to easily work with test data.
+      var something = await Fixture.Context.CreateSomething();
+      
+      var response = await Fixture.Client.GetAsJsonAsync($"/something/{something.Id}", request);
+      response.EnsureSuccessStatusCode();
+
+      var actualSomething = Fixture.Context.Something.Find(1);
+      var content = await response.Content.ReadFromJsonAsync<JObject>()
+      
+      // Assert response.
+      content.Value<int>("id", 1);
+  }
+}
+```
+
+## Note
+
+[More on integration tests.](https://docs.microsoft.com/en-us/aspnet/core/test/integration-tests?view=aspnetcore-5.0)

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,0 +1,208 @@
+# Remove the line below if you want to inherit .editorconfig settings from higher directories
+root = true
+
+# C# files
+[*.cs]
+
+#### Core EditorConfig Options ####
+
+# Indentation and spacing
+indent_size = 4
+indent_style = space
+tab_width = 4
+
+# New line preferences
+end_of_line = crlf
+insert_final_newline = false
+
+#### .NET Coding Conventions ####
+
+# Organize usings
+dotnet_separate_import_directive_groups = false
+dotnet_sort_system_directives_first = true
+
+# this. and Me. preferences
+dotnet_style_qualification_for_event = false:silent
+dotnet_style_qualification_for_field = false:silent
+dotnet_style_qualification_for_method = false:silent
+dotnet_style_qualification_for_property = false:silent
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent
+dotnet_style_predefined_type_for_member_access = true:silent
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
+
+# Expression-level preferences
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_prefer_compound_assignment = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
+dotnet_style_prefer_simplified_interpolation = true:suggestion
+
+# Field preferences
+dotnet_style_readonly_field = true:suggestion
+
+# Parameter preferences
+dotnet_code_quality_unused_parameters = all:suggestion
+
+#### C# Coding Conventions ####
+
+# var preferences
+csharp_style_var_elsewhere = false:suggestion
+csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_when_type_is_apparent = false:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = false:silent
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_prefer_switch_expression = true:suggestion
+
+# Null-checking preferences
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Modifier preferences
+csharp_prefer_static_local_function = true:suggestion
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:silent
+
+# Code-block preferences
+csharp_prefer_braces = true:warning
+csharp_prefer_simple_using_statement = true:suggestion
+
+# Expression-level preferences
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = false:suggestion
+csharp_style_prefer_index_operator = true:suggestion
+csharp_style_prefer_range_operator = true:suggestion
+csharp_style_throw_expression = true:suggestion
+csharp_style_unused_value_assignment_preference = discard_variable:suggestion
+csharp_style_unused_value_expression_statement_preference = discard_variable:silent
+
+# 'using' directive preferences
+csharp_using_directive_placement = outside_namespace:suggestion
+
+#### C# Formatting Rules ####
+
+# New line preferences
+csharp_new_line_before_catch = true
+csharp_new_line_before_else = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_before_members_in_object_initializers = true
+csharp_new_line_before_open_brace = all
+csharp_new_line_between_query_expression_clauses = true
+
+# Indentation preferences
+csharp_indent_block_contents = true
+csharp_indent_braces = false
+csharp_indent_case_contents = true
+csharp_indent_case_contents_when_block = true
+csharp_indent_labels = no_change
+csharp_indent_switch_labels = true
+
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_after_comma = true
+csharp_space_after_dot = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_after_semicolon_in_for_statement = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_around_declaration_statements = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_before_comma = false
+csharp_space_before_dot = false
+csharp_space_before_open_square_brackets = false
+csharp_space_before_semicolon_in_for_statement = false
+csharp_space_between_empty_square_brackets = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_between_square_brackets = false
+
+# Wrapping preferences
+csharp_preserve_single_line_blocks = true
+csharp_preserve_single_line_statements = true
+
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+# CA1303: Do not pass literals as localized parameters
+dotnet_diagnostic.CA1303.severity = silent
+
+# CA2007: Consider calling ConfigureAwait on the awaited task
+dotnet_diagnostic.CA2007.severity = silent
+
+# CA1031: Do not catch general exception types
+dotnet_diagnostic.CA1031.severity = silent

--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -20,94 +20,112 @@ insert_final_newline = false
 # Organize usings
 dotnet_separate_import_directive_groups = false
 dotnet_sort_system_directives_first = true
+file_header_template = unset
 
 # this. and Me. preferences
-dotnet_style_qualification_for_event = false:silent
-dotnet_style_qualification_for_field = false:silent
-dotnet_style_qualification_for_method = false:silent
-dotnet_style_qualification_for_property = false:silent
+dotnet_style_qualification_for_event = false
+dotnet_style_qualification_for_field = false
+dotnet_style_qualification_for_method = false
+dotnet_style_qualification_for_property = false
 
 # Language keywords vs BCL types preferences
-dotnet_style_predefined_type_for_locals_parameters_members = true:silent
-dotnet_style_predefined_type_for_member_access = true:silent
+dotnet_style_predefined_type_for_locals_parameters_members = true
+dotnet_style_predefined_type_for_member_access = true
 
 # Parentheses preferences
-dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
-dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
-dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
-dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
 
 # Modifier preferences
-dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
+dotnet_style_require_accessibility_modifiers = for_non_interface_members
 
 # Expression-level preferences
-dotnet_style_coalesce_expression = true:suggestion
-dotnet_style_collection_initializer = true:suggestion
-dotnet_style_explicit_tuple_names = true:suggestion
-dotnet_style_null_propagation = true:suggestion
-dotnet_style_object_initializer = true:suggestion
-dotnet_style_prefer_auto_properties = true:silent
-dotnet_style_prefer_compound_assignment = true:suggestion
-dotnet_style_prefer_conditional_expression_over_assignment = true:silent
-dotnet_style_prefer_conditional_expression_over_return = true:silent
-dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
-dotnet_style_prefer_inferred_tuple_names = true:suggestion
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
-dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
-dotnet_style_prefer_simplified_interpolation = true:suggestion
+dotnet_style_coalesce_expression = true
+dotnet_style_collection_initializer = true
+dotnet_style_explicit_tuple_names = true
+dotnet_style_namespace_match_folder = true
+dotnet_style_null_propagation = true
+dotnet_style_object_initializer = true
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+dotnet_style_prefer_auto_properties = true
+dotnet_style_prefer_compound_assignment = true
+dotnet_style_prefer_conditional_expression_over_assignment = true
+dotnet_style_prefer_conditional_expression_over_return = true
+dotnet_style_prefer_inferred_anonymous_type_member_names = true
+dotnet_style_prefer_inferred_tuple_names = true
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true
+dotnet_style_prefer_simplified_boolean_expressions = true
+dotnet_style_prefer_simplified_interpolation = true
 
 # Field preferences
-dotnet_style_readonly_field = true:suggestion
+dotnet_style_readonly_field = true
 
 # Parameter preferences
-dotnet_code_quality_unused_parameters = all:suggestion
+dotnet_code_quality_unused_parameters = all
+
+# Suppression preferences
+dotnet_remove_unnecessary_suppression_exclusions = none
+
+# New line preferences
+dotnet_style_allow_multiple_blank_lines_experimental = true
+dotnet_style_allow_statement_immediately_after_block_experimental = true
 
 #### C# Coding Conventions ####
 
 # var preferences
-csharp_style_var_elsewhere = false:suggestion
-csharp_style_var_for_built_in_types = false:suggestion
-csharp_style_var_when_type_is_apparent = false:suggestion
+csharp_style_var_elsewhere = false
+csharp_style_var_for_built_in_types = false
+csharp_style_var_when_type_is_apparent = false
 
 # Expression-bodied members
-csharp_style_expression_bodied_accessors = true:silent
-csharp_style_expression_bodied_constructors = false:silent
-csharp_style_expression_bodied_indexers = true:silent
-csharp_style_expression_bodied_lambdas = true:silent
-csharp_style_expression_bodied_local_functions = false:silent
-csharp_style_expression_bodied_methods = false:silent
-csharp_style_expression_bodied_operators = false:silent
-csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_accessors = true
+csharp_style_expression_bodied_constructors = false
+csharp_style_expression_bodied_indexers = true
+csharp_style_expression_bodied_lambdas = true
+csharp_style_expression_bodied_local_functions = false
+csharp_style_expression_bodied_methods = false
+csharp_style_expression_bodied_operators = false
+csharp_style_expression_bodied_properties = true
 
 # Pattern matching preferences
-csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
-csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
-csharp_style_prefer_switch_expression = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true
+csharp_style_pattern_matching_over_is_with_cast_check = true
+csharp_style_prefer_not_pattern = true
+csharp_style_prefer_pattern_matching = true
+csharp_style_prefer_switch_expression = true
 
 # Null-checking preferences
-csharp_style_conditional_delegate_call = true:suggestion
+csharp_style_conditional_delegate_call = true
 
 # Modifier preferences
-csharp_prefer_static_local_function = true:suggestion
-csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:silent
+csharp_prefer_static_local_function = true
+csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
 
 # Code-block preferences
-csharp_prefer_braces = true:warning
-csharp_prefer_simple_using_statement = true:suggestion
+csharp_prefer_braces = true
+csharp_prefer_simple_using_statement = true
 
 # Expression-level preferences
-csharp_prefer_simple_default_expression = true:suggestion
-csharp_style_deconstructed_variable_declaration = true:suggestion
-csharp_style_inlined_variable_declaration = true:suggestion
-csharp_style_pattern_local_over_anonymous_function = false:suggestion
-csharp_style_prefer_index_operator = true:suggestion
-csharp_style_prefer_range_operator = true:suggestion
-csharp_style_throw_expression = true:suggestion
-csharp_style_unused_value_assignment_preference = discard_variable:suggestion
-csharp_style_unused_value_expression_statement_preference = discard_variable:silent
+csharp_prefer_simple_default_expression = true
+csharp_style_deconstructed_variable_declaration = true
+csharp_style_implicit_object_creation_when_type_is_apparent = true
+csharp_style_inlined_variable_declaration = true
+csharp_style_pattern_local_over_anonymous_function = true
+csharp_style_prefer_index_operator = true
+csharp_style_prefer_range_operator = true
+csharp_style_throw_expression = true
+csharp_style_unused_value_assignment_preference = discard_variable
+csharp_style_unused_value_expression_statement_preference = discard_variable
 
 # 'using' directive preferences
-csharp_using_directive_placement = outside_namespace:suggestion
+csharp_using_directive_placement = outside_namespace
+
+# New line preferences
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = true
+csharp_style_allow_embedded_statements_on_same_line_experimental = true
 
 #### C# Formatting Rules ####
 
@@ -172,19 +190,28 @@ dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
 dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
 dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
 
+dotnet_naming_rule.private_or_internal_field_should_be_undercore_camel_case.severity = warning
+dotnet_naming_rule.private_or_internal_field_should_be_undercore_camel_case.symbols = private_or_internal_field
+dotnet_naming_rule.private_or_internal_field_should_be_undercore_camel_case.style = undercore_camel_case
+
 # Symbol specifications
 
 dotnet_naming_symbols.interface.applicable_kinds = interface
-dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal
 dotnet_naming_symbols.interface.required_modifiers = 
 
 dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
-dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal
 dotnet_naming_symbols.types.required_modifiers = 
 
 dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
-dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal
 dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+dotnet_naming_symbols.private_or_internal_field.applicable_kinds = field
+dotnet_naming_symbols.private_or_internal_field.applicable_accessibilities = internal, private
+dotnet_naming_symbols.private_or_internal_field.required_modifiers = 
+
 
 # Naming styles
 
@@ -198,11 +225,79 @@ dotnet_naming_style.begins_with_i.required_suffix =
 dotnet_naming_style.begins_with_i.word_separator = 
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
 
-# CA1303: Do not pass literals as localized parameters
-dotnet_diagnostic.CA1303.severity = silent
+dotnet_naming_style.undercore_camel_case.required_prefix = _
+dotnet_naming_style.undercore_camel_case.required_suffix = 
+dotnet_naming_style.undercore_camel_case.word_separator = 
+dotnet_naming_style.undercore_camel_case.capitalization = camel_case
 
-# CA2007: Consider calling ConfigureAwait on the awaited task
-dotnet_diagnostic.CA2007.severity = silent
+# CA1008: Enums should have zero value
+dotnet_diagnostic.CA1008.severity = none
+
+# CA1056: URI-like properties should not be strings
+dotnet_diagnostic.CA1056.severity = none
+
+# CA1014: Mark assemblies with CLSCompliantAttribute
+dotnet_diagnostic.CA1014.severity = none
+
+# CA1054: URI-like parameters should not be strings
+dotnet_diagnostic.CA1054.severity = none
+
+# CA1062: Validate arguments of public methods
+dotnet_diagnostic.CA1062.severity = none
+
+# CA1034: Nested types should not be visible
+dotnet_diagnostic.CA1034.severity = none
+
+# CA1724: Type names should not match namespaces
+dotnet_diagnostic.CA1724.severity = none
+
+# enables all coding style issues
+dotnet_analyzer_diagnostic.category-Style.severity = error
+
+# IDE0058: Expression value is never used
+dotnet_diagnostic.IDE0058.severity = none
+
+# https://github.com/dotnet/roslyn/issues/55550
+# IDE0130: Namespace does not match folder structure
+dotnet_diagnostic.IDE0130.severity = none
+
+# IDE0072: Add missing cases
+dotnet_diagnostic.IDE0072.severity = suggestion
+
+# IDE0010: Add missing cases
+dotnet_diagnostic.IDE0010.severity = suggestion
+
+# IDE0008: Use explicit type
+dotnet_diagnostic.IDE0008.severity = silent
+
+# IDE0046: Convert to conditional expression
+dotnet_diagnostic.IDE0046.severity = silent
+
+# IDE0028: Simplify collection initialization
+dotnet_diagnostic.IDE0028.severity = silent
+
+# IDE0037: Use inferred member name
+dotnet_diagnostic.IDE0037.severity = silent
+
+# IDE0022: Use block body for methods
+dotnet_diagnostic.IDE0022.severity = silent
+
+# IDE0052: Remove unread private members
+dotnet_diagnostic.IDE0052.severity = error
+
+# IDE0090 Use 'new(...)'
+dotnet_diagnostic.IDE0090.severity = suggestion
+
+# CA1308 // Normalize strings to uppercase
+dotnet_diagnostic.CA1308.severity = none
+
+# CS1591 Missing XML comment for publicly visible type or member
+dotnet_diagnostic.CS1591.severity = none
+
+# According to rule recommendations we can skip this if we know the environment
+# https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca2007#when-to-suppress-warnings
+# CA2007: Do not directly await a Task
+dotnet_diagnostic.CA2007.severity = none
 
 # CA1031: Do not catch general exception types
-dotnet_diagnostic.CA1031.severity = silent
+dotnet_diagnostic.CA1031.severity = suggestion

--- a/src/Likvido.Test.Api.sln
+++ b/src/Likvido.Test.Api.sln
@@ -5,12 +5,14 @@ VisualStudioVersion = 16.0.31702.278
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{9445A89C-4010-466A-97C7-920B2AED7DD6}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		..\.github\workflows\nuget.yml = ..\.github\workflows\nuget.yml
 		..\README.md = ..\README.md
+		shared.props = shared.props
 		version.props = version.props
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Likvido.Test.Api", "Likvido.Test.Api\Likvido.Test.Api.csproj", "{579EF172-AD10-4C66-B7F8-8832B0AA2596}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Likvido.Test.Api", "Likvido.Test.Api\Likvido.Test.Api.csproj", "{579EF172-AD10-4C66-B7F8-8832B0AA2596}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Likvido.Test.Api.sln
+++ b/src/Likvido.Test.Api.sln
@@ -1,0 +1,32 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31702.278
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{9445A89C-4010-466A-97C7-920B2AED7DD6}"
+	ProjectSection(SolutionItems) = preProject
+		..\.github\workflows\nuget.yml = ..\.github\workflows\nuget.yml
+		..\README.md = ..\README.md
+		version.props = version.props
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Likvido.Test.Api", "Likvido.Test.Api\Likvido.Test.Api.csproj", "{579EF172-AD10-4C66-B7F8-8832B0AA2596}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{579EF172-AD10-4C66-B7F8-8832B0AA2596}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{579EF172-AD10-4C66-B7F8-8832B0AA2596}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{579EF172-AD10-4C66-B7F8-8832B0AA2596}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{579EF172-AD10-4C66-B7F8-8832B0AA2596}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {782A49EA-D057-4939-829A-EB8996AD4932}
+	EndGlobalSection
+EndGlobal

--- a/src/Likvido.Test.Api/Base/ConfigurableTestFixture.cs
+++ b/src/Likvido.Test.Api/Base/ConfigurableTestFixture.cs
@@ -7,7 +7,7 @@ namespace Likvido.Test.Api
     public abstract class ConfigurableTestFixture<TStartup, TDesignContext, TRuntimeContext>
         : TestFixture<TStartup, TDesignContext, TRuntimeContext>
         where TStartup : class
-        where TDesignContext : TRuntimeContext
+        where TDesignContext : DbContext
         where TRuntimeContext : DbContext
     {
         private FixtureOptions<TDesignContext, TRuntimeContext>? _fixtureOptions;

--- a/src/Likvido.Test.Api/Base/ConfigurableTestFixture.cs
+++ b/src/Likvido.Test.Api/Base/ConfigurableTestFixture.cs
@@ -4,6 +4,13 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Likvido.Test.Api
 {
+    public abstract class ConfigurableTestFixture<TStartup, TContext>
+        : ConfigurableTestFixture<TStartup, TContext, TContext>
+        where TStartup : class
+        where TContext : DbContext
+    {
+    }
+
     public abstract class ConfigurableTestFixture<TStartup, TDesignContext, TRuntimeContext>
         : TestFixture<TStartup, TDesignContext, TRuntimeContext>
         where TStartup : class

--- a/src/Likvido.Test.Api/Base/ConfigurableTestFixture.cs
+++ b/src/Likvido.Test.Api/Base/ConfigurableTestFixture.cs
@@ -9,6 +9,10 @@ namespace Likvido.Test.Api
         where TStartup : class
         where TContext : DbContext
     {
+        protected ConfigurableTestFixture(FixtureOptions<TContext> fixtureOptions)
+            : base(fixtureOptions)
+        {
+        }
     }
 
     public abstract class ConfigurableTestFixture<TStartup, TDesignContext, TRuntimeContext>

--- a/src/Likvido.Test.Api/Base/ConfigurableTestFixture.cs
+++ b/src/Likvido.Test.Api/Base/ConfigurableTestFixture.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Likvido.Test.Api
+{
+    public abstract class ConfigurableTestFixture<TStartup, TDesignContext, TRuntimeContext>
+        : TestFixture<TStartup, TDesignContext, TRuntimeContext>
+        where TStartup : class
+        where TDesignContext : TRuntimeContext
+        where TRuntimeContext : DbContext
+    {
+        private FixtureOptions<TDesignContext, TRuntimeContext>? _fixtureOptions;
+
+        protected ConfigurableTestFixture()
+        {
+        }
+
+        protected ConfigurableTestFixture(FixtureOptions<TDesignContext, TRuntimeContext> fixtureOptions)
+        {
+            SetOptions(fixtureOptions);
+        }
+
+        protected ConfigurableTestFixture(DatabaseFixture<TDesignContext, TRuntimeContext> databaseFixture)
+        {
+            SetDbFixture(databaseFixture);
+        }
+
+        protected ConfigurableTestFixture(Action<IServiceCollection> configureServices)
+        {
+            SetConfigureServices(configureServices);
+        }
+
+        public void SetOptions(FixtureOptions<TDesignContext, TRuntimeContext> fixtureOptions)
+        {
+            _fixtureOptions = fixtureOptions;
+            CleanBuilder();
+        }
+
+        public void SetConfigureServices(Action<IServiceCollection> configureServices)
+        {
+            var fixtureOptions = _fixtureOptions ?? new FixtureOptions<TDesignContext, TRuntimeContext>();
+            fixtureOptions.ConfigureServices = configureServices;
+            SetOptions(fixtureOptions);
+        }
+
+        public void SetDbFixture(DatabaseFixture<TDesignContext, TRuntimeContext> databaseFixture)
+        {
+            var fixtureOptions = _fixtureOptions ?? new FixtureOptions<TDesignContext, TRuntimeContext>();
+            fixtureOptions.DatabaseFixture = databaseFixture;
+            SetOptions(fixtureOptions);
+        }
+
+        protected override FixtureOptions<TDesignContext, TRuntimeContext>? GetFixtureOptions()
+        {
+            return _fixtureOptions;
+        }
+    }
+}

--- a/src/Likvido.Test.Api/Base/FixtureOptions.cs
+++ b/src/Likvido.Test.Api/Base/FixtureOptions.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using Likvido.Test.Api;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Likvido.Test.Api
+{
+    public class FixtureOptions<TDesignContext, TRuntimeContext>
+        where TDesignContext : TRuntimeContext
+        where TRuntimeContext : DbContext
+    {
+        public DatabaseFixture<TDesignContext, TRuntimeContext>? DatabaseFixture { get; set; }
+        public Action<IServiceCollection>? ConfigureServices { get; set; }
+        public Dictionary<string, Action<HttpClient, IConfiguration>> ConfigureNamedHttpClients { get; set; } = new();
+    }
+}

--- a/src/Likvido.Test.Api/Base/FixtureOptions.cs
+++ b/src/Likvido.Test.Api/Base/FixtureOptions.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Net.Http;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Likvido.Test.Api
@@ -20,7 +19,7 @@ namespace Likvido.Test.Api
         public Action<IServiceCollection>? ConfigureServices { get; set; }
         public Action<IServiceCollection, Func<TRuntimeContext>>? ConfigureContext { get; set; }
 #pragma warning disable CA2227 // Collection properties should be read only
-        public Dictionary<string, Action<HttpClient, IConfiguration>> ConfigureNamedHttpClients { get; set; } = new();
+        public Dictionary<string, Action<IServiceProvider, HttpClient>> ConfigureNamedHttpClients { get; set; } = new();
 #pragma warning restore CA2227 // Collection properties should be read only
     }
 }

--- a/src/Likvido.Test.Api/Base/FixtureOptions.cs
+++ b/src/Likvido.Test.Api/Base/FixtureOptions.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Likvido.Test.Api
 {
     public class FixtureOptions<TDesignContext, TRuntimeContext>
-        where TDesignContext : TRuntimeContext
+        where TDesignContext : DbContext
         where TRuntimeContext : DbContext
     {
         public DatabaseFixture<TDesignContext, TRuntimeContext>? DatabaseFixture { get; set; }

--- a/src/Likvido.Test.Api/Base/FixtureOptions.cs
+++ b/src/Likvido.Test.Api/Base/FixtureOptions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using Likvido.Test.Api;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -14,6 +13,6 @@ namespace Likvido.Test.Api
     {
         public DatabaseFixture<TDesignContext, TRuntimeContext>? DatabaseFixture { get; set; }
         public Action<IServiceCollection>? ConfigureServices { get; set; }
-        public Dictionary<string, Action<HttpClient, IConfiguration>> ConfigureNamedHttpClients { get; set; } = new();
+        public Dictionary<string, Action<HttpClient, IConfiguration>> ConfigureNamedHttpClients { get; } = new();
     }
 }

--- a/src/Likvido.Test.Api/Base/FixtureOptions.cs
+++ b/src/Likvido.Test.Api/Base/FixtureOptions.cs
@@ -13,6 +13,9 @@ namespace Likvido.Test.Api
     {
         public DatabaseFixture<TDesignContext, TRuntimeContext>? DatabaseFixture { get; set; }
         public Action<IServiceCollection>? ConfigureServices { get; set; }
-        public Dictionary<string, Action<HttpClient, IConfiguration>> ConfigureNamedHttpClients { get; } = new();
+        public Action<IServiceCollection, Func<TRuntimeContext>>? ConfigureContext { get; set; }
+#pragma warning disable CA2227 // Collection properties should be read only
+        public Dictionary<string, Action<HttpClient, IConfiguration>> ConfigureNamedHttpClients { get; set; } = new();
+#pragma warning restore CA2227 // Collection properties should be read only
     }
 }

--- a/src/Likvido.Test.Api/Base/FixtureOptions.cs
+++ b/src/Likvido.Test.Api/Base/FixtureOptions.cs
@@ -7,6 +7,11 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Likvido.Test.Api
 {
+    public class FixtureOptions<TContext> : FixtureOptions<TContext, TContext>
+        where TContext : DbContext
+    {
+    }
+
     public class FixtureOptions<TDesignContext, TRuntimeContext>
         where TDesignContext : DbContext
         where TRuntimeContext : DbContext

--- a/src/Likvido.Test.Api/Base/TestFixture.cs
+++ b/src/Likvido.Test.Api/Base/TestFixture.cs
@@ -41,11 +41,11 @@ namespace Likvido.Test.Api
             get
             {
                 var options = GetFixtureOptions();
-                if (options?.DatabaseFixture?.Context == null)
+                if (options?.DatabaseFixture?.DesignContext == null)
                 {
                     throw new InvalidOperationException("No context was configured for this fixture");
                 }
-                return options.DatabaseFixture.Context;
+                return options.DatabaseFixture.DesignContext;
             }
         }
 
@@ -61,7 +61,14 @@ namespace Likvido.Test.Api
                     fixtureOptions?.ConfigureServices?.Invoke(s);
                     if (fixtureOptions?.DatabaseFixture != null)
                     {
-                        s.AddScoped(_ => fixtureOptions.DatabaseFixture.CreateRuntimeContext());
+                        if (fixtureOptions.ConfigureContext != null)
+                        {
+                            fixtureOptions.ConfigureContext.Invoke(s, fixtureOptions.DatabaseFixture.CreateRuntimeContext);
+                        }
+                        else
+                        {
+                            s.AddScoped(_ => fixtureOptions.DatabaseFixture.CreateRuntimeContext());
+                        }
                     }
                 },
                 ConfigureNamedHttpClients = fixtureOptions?.ConfigureNamedHttpClients

--- a/src/Likvido.Test.Api/Base/TestFixture.cs
+++ b/src/Likvido.Test.Api/Base/TestFixture.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Reflection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+
+namespace Likvido.Test.Api
+{
+    public abstract class TestFixture<TStartup, TDesignContext, TRuntimeContext> : TestFixtureBase
+        where TStartup : class
+        where TDesignContext : TRuntimeContext
+        where TRuntimeContext : DbContext
+    {
+        private HttpClientFactory<TStartup>? _clientBuilder { get; set; }
+        protected HttpClientFactory<TStartup> HttpClientFactory
+        {
+            get
+            {
+                if (_clientBuilder == null)
+                {
+                    throw new InvalidOperationException($"Method \"{nameof(TestStarted)}\" should be called first");
+                }
+
+                return _clientBuilder;
+            }
+
+        }
+
+        public virtual HttpClient Client => HttpClientFactory.HttpClient;
+
+        public TRuntimeContext Context
+        {
+            get
+            {
+                var options = GetFixtureOptions();
+                if (options?.DatabaseFixture?.Context == null)
+                {
+                    throw new InvalidOperationException("No context was configured for this fixture");
+                }
+                return options.DatabaseFixture.Context;
+            }
+        }
+
+        protected override void OnTestStarted()
+        {
+            var configuration = GetFixtureOptions();
+            _clientBuilder ??= HttpClientFactoryBuilder<TStartup>.Build(new HttpClientFactoryBuilderOptions
+            {
+                ConfigureServices = s =>
+                {
+                    ConfigureMocks(s);
+                    configuration?.ConfigureServices?.Invoke(s);
+                    if (configuration?.DatabaseFixture != null)
+                    {
+                        s.AddScoped(_ => configuration.DatabaseFixture.CreateRuntimeContext());
+                    }
+                },
+                ConfigureNamedHttpClients = configuration?.ConfigureNamedHttpClients
+            });
+
+            GetFixtureOptions()?.DatabaseFixture?.CreateTestData();
+        }
+
+        protected override void OnTestEnded()
+        {
+            GetFixtureOptions()?.DatabaseFixture?.Cleanup();
+            ResetMocks();
+        }
+
+        protected virtual FixtureOptions<TDesignContext, TRuntimeContext>? GetFixtureOptions()
+        {
+            return null;
+        }
+
+        protected override void OnDisposing()
+        {
+            base.OnDisposing();
+            GetFixtureOptions()?.DatabaseFixture?.Dispose();
+            CleanBuilder();
+        }
+
+        protected void CleanBuilder()
+        {
+            _clientBuilder?.Dispose();
+            _clientBuilder = null;
+        }
+
+        private List<(Type ServiceType, Mock Mock)>? _mocks;
+
+        private void ConfigureMocks(IServiceCollection services)
+        {
+            _mocks = GetType()
+                .GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(x => typeof(Mock).IsAssignableFrom(x.PropertyType))
+                .Select(x => (x.PropertyType.GetGenericArguments()[0], (Mock)x.GetValue(this)!))
+                .ToList();
+
+            _mocks.ForEach(x => services.AddSingleton(x.ServiceType, x.Mock.Object));
+        }
+
+        private void ResetMocks()
+        {
+            _mocks?.ForEach(x => x.Mock.Reset());
+        }
+    }
+}

--- a/src/Likvido.Test.Api/Base/TestFixture.cs
+++ b/src/Likvido.Test.Api/Base/TestFixture.cs
@@ -11,7 +11,7 @@ namespace Likvido.Test.Api
 {
     public abstract class TestFixture<TStartup, TDesignContext, TRuntimeContext> : TestFixtureBase
         where TStartup : class
-        where TDesignContext : TRuntimeContext
+        where TDesignContext : DbContext
         where TRuntimeContext : DbContext
     {
         private HttpClientFactory<TStartup>? _httpClientFactory;

--- a/src/Likvido.Test.Api/Base/TestFixtureBase.cs
+++ b/src/Likvido.Test.Api/Base/TestFixtureBase.cs
@@ -24,7 +24,7 @@ namespace Likvido.Test.Api
 
 
         #region IDisposable Support
-        private bool disposedValue; // To detect redundant calls
+        private bool _disposedValue; // To detect redundant calls
 
         protected virtual void OnDisposing()
         {
@@ -32,14 +32,14 @@ namespace Likvido.Test.Api
 
         protected virtual void Dispose(bool disposing)
         {
-            if (!disposedValue)
+            if (!_disposedValue)
             {
                 if (disposing)
                 {
                     OnDisposing();
                 }
 
-                disposedValue = true;
+                _disposedValue = true;
             }
         }
 

--- a/src/Likvido.Test.Api/Base/TestFixtureBase.cs
+++ b/src/Likvido.Test.Api/Base/TestFixtureBase.cs
@@ -1,0 +1,56 @@
+﻿using System;
+
+namespace Likvido.Test.Api
+{
+    public abstract class TestFixtureBase : IDisposable
+    {
+        public void TestStarted()
+        {
+            OnTestStarted();
+        }
+
+        public void TestEnded()
+        {
+            OnTestEnded();
+        }
+
+        protected virtual void OnTestEnded()
+        {
+        }
+
+        protected virtual void OnTestStarted()
+        {
+        }
+
+
+        #region IDisposable Support
+        private bool disposedValue; // To detect redundant calls
+
+        protected virtual void OnDisposing()
+        {
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    OnDisposing();
+                }
+
+                disposedValue = true;
+            }
+        }
+
+        // This code added to correctly implement the disposable pattern.
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        #endregion
+
+    }
+}

--- a/src/Likvido.Test.Api/Base/TestsBase.cs
+++ b/src/Likvido.Test.Api/Base/TestsBase.cs
@@ -6,7 +6,8 @@ namespace Likvido.Test.Api
         where TFixture : TestFixtureBase
     {
         protected bool IsPersistentFixture { get; set; }
-        protected TFixture? _fixture { get; set; }
+        private TFixture? _fixture;
+
         public TFixture Fixture
         {
             get

--- a/src/Likvido.Test.Api/Base/TestsBase.cs
+++ b/src/Likvido.Test.Api/Base/TestsBase.cs
@@ -6,7 +6,9 @@ namespace Likvido.Test.Api
         where TFixture : TestFixtureBase
     {
         protected bool IsPersistentFixture { get; set; }
-        private TFixture? _fixture;
+#pragma warning disable CA1051 // Do not declare visible instance fields
+        protected TFixture? _fixture;
+#pragma warning restore CA1051 // Do not declare visible instance fields
 
         public TFixture Fixture
         {

--- a/src/Likvido.Test.Api/Base/TestsBase.cs
+++ b/src/Likvido.Test.Api/Base/TestsBase.cs
@@ -1,0 +1,61 @@
+﻿using System;
+
+namespace Likvido.Test.Api
+{
+    public abstract class TestsBase<TFixture> : IDisposable
+        where TFixture : TestFixtureBase
+    {
+        protected bool IsPersistentFixture { get; set; }
+        protected TFixture? _fixture { get; set; }
+        public TFixture Fixture
+        {
+            get
+            {
+                if (_fixture == null)
+                {
+                    throw new InvalidOperationException("Fixture must be configured before usage");
+                }
+
+                return _fixture;
+            }
+        }
+
+        protected TestsBase()
+        {
+            IsPersistentFixture = false;
+        }
+
+        protected TestsBase(TFixture fixture)
+        {
+            _fixture = fixture;
+            IsPersistentFixture = true;
+            InitializeFixture();
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposing)
+            {
+                return;
+            }
+
+            _fixture?.TestEnded();
+            if (!IsPersistentFixture)
+            {
+                _fixture?.Dispose();
+                _fixture = null;
+            }
+        }
+
+        protected void InitializeFixture()
+        {
+            _fixture?.TestStarted();
+        }
+    }
+}

--- a/src/Likvido.Test.Api/DbFixtures/BaseTestDataHelper.cs
+++ b/src/Likvido.Test.Api/DbFixtures/BaseTestDataHelper.cs
@@ -10,17 +10,17 @@ namespace Likvido.Test.Api
     {
         private IDictionary<string, string[]>? _beforeCleanupCommands;
         private IDictionary<string, string[]>? _specialCleanupCommands;
-        protected bool _testDataCreated;
-        protected readonly Func<TContext> _context;
-        protected readonly Func<string, string> _q;
+        protected bool TestDataCreated { get; private set; }
+        protected Func<TContext> GetContext { get; }
+        protected Func<string, string> Quote { get; }
 
         public BaseTestDataHelper(Func<TContext> context, Func<string, string> quote)
         {
-            _context = context;
-            _q = quote;
+            GetContext = context;
+            Quote = quote;
         }
 
-        protected TContext Context => _context();
+        protected TContext Context => GetContext();
 
         public virtual void Cleanup()
         {
@@ -37,7 +37,7 @@ namespace Likvido.Test.Api
                     }
                 }
 
-                if (_testDataCreated && specialCleanupCommands.ContainsKey(tableName))
+                if (TestDataCreated && specialCleanupCommands.ContainsKey(tableName))
                 {
                     foreach (var command in specialCleanupCommands[tableName])
                     {
@@ -46,7 +46,7 @@ namespace Likvido.Test.Api
                 }
                 else
                 {
-                    Context.Database.ExecuteSqlRaw($@"DELETE FROM {_q(tableName)}");
+                    Context.Database.ExecuteSqlRaw($@"DELETE FROM {Quote(tableName)}");
                 }
             }
         }
@@ -58,7 +58,7 @@ namespace Likvido.Test.Api
 
         public void CreateTestData()
         {
-            if (_testDataCreated)
+            if (TestDataCreated)
             {
                 return;
             }
@@ -67,7 +67,7 @@ namespace Likvido.Test.Api
 
             GenerateTestDataAsync().Wait();
 
-            _testDataCreated = true;
+            TestDataCreated = true;
         }
 
         public virtual Task GenerateTestDataAsync()

--- a/src/Likvido.Test.Api/DbFixtures/BaseTestDataHelper.cs
+++ b/src/Likvido.Test.Api/DbFixtures/BaseTestDataHelper.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+
+namespace Likvido.Test.Api
+{
+    public class BaseTestDataHelper<TContext> : ITestDataHelper
+        where TContext : DbContext
+    {
+        private IDictionary<string, string[]>? _beforeCleanupCommands;
+        private IDictionary<string, string[]>? _specialCleanupCommands;
+        protected bool _testDataCreated;
+        protected readonly Func<TContext> _context;
+        protected readonly Func<string, string> _q;
+
+        public BaseTestDataHelper(Func<TContext> context, Func<string, string> quote)
+        {
+            _context = context;
+            _q = quote;
+        }
+
+        protected TContext Context => _context();
+
+        public virtual void Cleanup()
+        {
+            var beforeCleanupCommands = GetBeforeCleanupCommands();
+            var specialCleanupCommands = GetSpecialCleanupCommands();
+
+            foreach (var tableName in GetCleanupTables())
+            {
+                if (beforeCleanupCommands.ContainsKey(tableName))
+                {
+                    foreach (var command in beforeCleanupCommands[tableName])
+                    {
+                        Context.Database.ExecuteSqlRaw(command);
+                    }
+                }
+
+                if (_testDataCreated && specialCleanupCommands.ContainsKey(tableName))
+                {
+                    foreach (var command in specialCleanupCommands[tableName])
+                    {
+                        Context.Database.ExecuteSqlRaw(command);
+                    }
+                }
+                else
+                {
+                    Context.Database.ExecuteSqlRaw($@"DELETE FROM {_q(tableName)}");
+                }
+            }
+        }
+
+        public virtual string[] GetCleanupTables()
+        {
+            return Array.Empty<string>();
+        }
+
+        public void CreateTestData()
+        {
+            if (_testDataCreated)
+            {
+                return;
+            }
+
+            Cleanup();
+
+            GenerateTestDataAsync().Wait();
+
+            _testDataCreated = true;
+        }
+
+        public virtual Task GenerateTestDataAsync()
+        {
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Removes foreign keys if required
+        /// </summary>
+        public virtual IDictionary<string, string[]> GenerateBeforeCleanupCommands()
+        {
+            return new Dictionary<string, string[]>();
+        }
+
+        /// <summary>
+        /// If some test data need to be kept
+        /// </summary>
+        public virtual IDictionary<string, string[]> GenerateSpecialCleanupCommands()
+        {
+            return new Dictionary<string, string[]>();
+        }
+
+        private IDictionary<string, string[]> GetBeforeCleanupCommands()
+        {
+            return _beforeCleanupCommands ??= GenerateBeforeCleanupCommands();
+        }
+
+        private IDictionary<string, string[]> GetSpecialCleanupCommands()
+        {
+            return _specialCleanupCommands ??= GenerateSpecialCleanupCommands();
+        }
+    }
+}

--- a/src/Likvido.Test.Api/DbFixtures/ContextFixtureBase.cs
+++ b/src/Likvido.Test.Api/DbFixtures/ContextFixtureBase.cs
@@ -11,25 +11,13 @@ namespace Likvido.Test.Api
         private TRuntimeContext? _runtimeContext;
         private bool _migrated;
 
-        public TRuntimeContext RuntimeContext
-        {
-            get
-            {
-                if (_runtimeContext == null)
-                {
-                    ResetContext();
-                }
-                return _runtimeContext!;
-            }
-        }
-
         public TDesignContext DesignContext
         {
             get
             {
                 if (_designContext == null)
                 {
-                    ResetContext();
+                    ResetDesignContext();
                 }
                 return _designContext!;
             }
@@ -49,12 +37,16 @@ namespace Likvido.Test.Api
             _migrated = true;
         }
 
-        public (TDesignContext Design, TRuntimeContext Runtime) Create()
+        private TDesignContext CreateDesignContext()
         {
             var designContext = GenerateDesignContext();
             Migrate(designContext);
-            var runtimeContext = GenerateRuntimeContext();
-            return (designContext, runtimeContext);
+            return designContext;
+        }
+
+        public TRuntimeContext CreateRuntimeContext()
+        {
+            return GenerateRuntimeContext();
         }
 
         public void CreateTestData()
@@ -65,7 +57,7 @@ namespace Likvido.Test.Api
         public void Cleanup()
         {
             GetTestDataHelper().Cleanup();
-            ResetContext();
+            ResetContexts();
         }
 
         public abstract void ExecuteMigration(TDesignContext context);
@@ -96,11 +88,17 @@ namespace Likvido.Test.Api
             return $"[{value}]";
         }
 
-        private void ResetContext()
+        private void ResetDesignContext()
         {
             _designContext?.Dispose();
+            _designContext = CreateDesignContext();
+        }
+
+        private void ResetContexts()
+        {
+            ResetDesignContext();
             _runtimeContext?.Dispose();
-            (_designContext, _runtimeContext) = Create();
+            _runtimeContext = CreateRuntimeContext();
         }
     }
 }

--- a/src/Likvido.Test.Api/DbFixtures/ContextFixtureBase.cs
+++ b/src/Likvido.Test.Api/DbFixtures/ContextFixtureBase.cs
@@ -4,7 +4,7 @@ using Microsoft.EntityFrameworkCore;
 namespace Likvido.Test.Api
 {
     public abstract class ContextFixtureBase<TDesignContext, TRuntimeContext> : IDisposable
-        where TDesignContext : TRuntimeContext
+        where TDesignContext : DbContext
         where TRuntimeContext : DbContext
     {
         private TDesignContext? _designContext;

--- a/src/Likvido.Test.Api/DbFixtures/ContextFixtureBase.cs
+++ b/src/Likvido.Test.Api/DbFixtures/ContextFixtureBase.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore;
+
+namespace Likvido.Test.Api
+{
+    public abstract class ContextFixtureBase<TDesignContext, TRuntimeContext> : IDisposable
+        where TDesignContext : TRuntimeContext
+        where TRuntimeContext : DbContext
+    {
+        private TDesignContext? _designContext;
+        private TRuntimeContext? _runtimeContext;
+        private bool _migrated;
+
+        public TRuntimeContext RuntimeContext
+        {
+            get
+            {
+                if (_runtimeContext == null)
+                {
+                    ResetContext();
+                }
+                return _runtimeContext!;
+            }
+        }
+
+        public TDesignContext DesignContext
+        {
+            get
+            {
+                if (_designContext == null)
+                {
+                    ResetContext();
+                }
+                return _designContext!;
+            }
+        }
+
+        public abstract TDesignContext GenerateDesignContext();
+        public abstract TRuntimeContext GenerateRuntimeContext();
+
+        public void Migrate(TDesignContext context)
+        {
+            if (_migrated)
+            {
+                return;
+            }
+
+            ExecuteMigration(context);
+            _migrated = true;
+        }
+
+        public (TDesignContext Design, TRuntimeContext Runtime) Create()
+        {
+            var designContext = GenerateDesignContext();
+            Migrate(designContext);
+            var runtimeContext = GenerateRuntimeContext();
+            return (designContext, runtimeContext);
+        }
+
+        public void CreateTestData()
+        {
+            GetTestDataHelper().CreateTestData();
+        }
+
+        public void Cleanup()
+        {
+            GetTestDataHelper().Cleanup();
+            ResetContext();
+        }
+
+        public abstract void ExecuteMigration(TDesignContext context);
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposing)
+            {
+                return;
+            }
+
+            _designContext?.Dispose();
+            _runtimeContext?.Dispose();
+            _designContext = null;
+            _runtimeContext = null;
+        }
+
+        protected abstract ITestDataHelper GetTestDataHelper();
+
+        public virtual string Quote(string value)
+        {
+            return $"[{value}]";
+        }
+
+        private void ResetContext()
+        {
+            _designContext?.Dispose();
+            _runtimeContext?.Dispose();
+            (_designContext, _runtimeContext) = Create();
+        }
+    }
+}

--- a/src/Likvido.Test.Api/DbFixtures/ContextFixtureBase.cs
+++ b/src/Likvido.Test.Api/DbFixtures/ContextFixtureBase.cs
@@ -8,7 +8,6 @@ namespace Likvido.Test.Api
         where TRuntimeContext : DbContext
     {
         private TDesignContext? _designContext;
-        private TRuntimeContext? _runtimeContext;
         private bool _migrated;
 
         public TDesignContext DesignContext
@@ -57,7 +56,7 @@ namespace Likvido.Test.Api
         public void Cleanup()
         {
             GetTestDataHelper().Cleanup();
-            ResetContexts();
+            ResetDesignContext();
         }
 
         public abstract void ExecuteMigration(TDesignContext context);
@@ -76,9 +75,7 @@ namespace Likvido.Test.Api
             }
 
             _designContext?.Dispose();
-            _runtimeContext?.Dispose();
             _designContext = null;
-            _runtimeContext = null;
         }
 
         protected abstract ITestDataHelper GetTestDataHelper();
@@ -92,13 +89,6 @@ namespace Likvido.Test.Api
         {
             _designContext?.Dispose();
             _designContext = CreateDesignContext();
-        }
-
-        private void ResetContexts()
-        {
-            ResetDesignContext();
-            _runtimeContext?.Dispose();
-            _runtimeContext = CreateRuntimeContext();
         }
     }
 }

--- a/src/Likvido.Test.Api/DbFixtures/DatabaseFixture.cs
+++ b/src/Likvido.Test.Api/DbFixtures/DatabaseFixture.cs
@@ -9,7 +9,7 @@ namespace Likvido.Test.Api
     {
         public abstract ContextFixtureBase<TDesignContext, TRuntimeContext> ContextFixture { get; }
 
-        public TDesignContext Context => ContextFixture.DesignContext;
+        public TDesignContext DesignContext => ContextFixture.DesignContext;
 
         public abstract DatabaseFixtureType DbType { get; }
 

--- a/src/Likvido.Test.Api/DbFixtures/DatabaseFixture.cs
+++ b/src/Likvido.Test.Api/DbFixtures/DatabaseFixture.cs
@@ -9,7 +9,7 @@ namespace Likvido.Test.Api
     {
         public abstract ContextFixtureBase<TDesignContext, TRuntimeContext> ContextFixture { get; }
 
-        public TRuntimeContext Context => ContextFixture.RuntimeContext;
+        public TDesignContext Context => ContextFixture.DesignContext;
 
         public abstract DatabaseFixtureType DbType { get; }
 

--- a/src/Likvido.Test.Api/DbFixtures/DatabaseFixture.cs
+++ b/src/Likvido.Test.Api/DbFixtures/DatabaseFixture.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore;
+
+namespace Likvido.Test.Api
+{
+    public abstract class DatabaseFixture<TDesignContext, TRuntimeContext> : IDisposable
+        where TDesignContext : TRuntimeContext
+        where TRuntimeContext : DbContext
+    {
+        public abstract ContextFixtureBase<TDesignContext, TRuntimeContext> ContextFixture { get; }
+
+        public TRuntimeContext Context => ContextFixture.RuntimeContext;
+
+        public abstract DatabaseFixtureType DbType { get; }
+
+        public TRuntimeContext CreateRuntimeContext()
+        {
+            return ContextFixture.Create().Runtime;
+        }
+
+        public void CreateTestData()
+        {
+            ContextFixture.CreateTestData();
+        }
+
+        public void Cleanup()
+        {
+            ContextFixture.Cleanup();
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposing)
+            {
+                return;
+            }
+
+            ContextFixture?.Dispose();
+        }
+    }
+}

--- a/src/Likvido.Test.Api/DbFixtures/DatabaseFixture.cs
+++ b/src/Likvido.Test.Api/DbFixtures/DatabaseFixture.cs
@@ -4,7 +4,7 @@ using Microsoft.EntityFrameworkCore;
 namespace Likvido.Test.Api
 {
     public abstract class DatabaseFixture<TDesignContext, TRuntimeContext> : IDisposable
-        where TDesignContext : TRuntimeContext
+        where TDesignContext : DbContext
         where TRuntimeContext : DbContext
     {
         public abstract ContextFixtureBase<TDesignContext, TRuntimeContext> ContextFixture { get; }

--- a/src/Likvido.Test.Api/DbFixtures/DatabaseFixture.cs
+++ b/src/Likvido.Test.Api/DbFixtures/DatabaseFixture.cs
@@ -15,7 +15,7 @@ namespace Likvido.Test.Api
 
         public TRuntimeContext CreateRuntimeContext()
         {
-            return ContextFixture.Create().Runtime;
+            return ContextFixture.CreateRuntimeContext();
         }
 
         public void CreateTestData()

--- a/src/Likvido.Test.Api/DbFixtures/DatabaseFixtureType.cs
+++ b/src/Likvido.Test.Api/DbFixtures/DatabaseFixtureType.cs
@@ -1,0 +1,7 @@
+﻿namespace Likvido.Test.Api
+{
+    public enum DatabaseFixtureType
+    {
+        Sqlite = 1
+    }
+}

--- a/src/Likvido.Test.Api/DbFixtures/ITestDataHelper.cs
+++ b/src/Likvido.Test.Api/DbFixtures/ITestDataHelper.cs
@@ -1,0 +1,8 @@
+﻿namespace Likvido.Test.Api
+{
+    public interface ITestDataHelper
+    {
+        void CreateTestData();
+        void Cleanup();
+    }
+}

--- a/src/Likvido.Test.Api/DbFixtures/Sqlite/SqliteContextFixture.cs
+++ b/src/Likvido.Test.Api/DbFixtures/Sqlite/SqliteContextFixture.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore.Migrations;
 namespace Likvido.Test.Api.Sqlite
 {
     public abstract class SqliteContextFixture<TDesignContext, TRuntimeContext> : ContextFixtureBase<TDesignContext, TRuntimeContext>
-        where TDesignContext : TRuntimeContext
+        where TDesignContext : DbContext
         where TRuntimeContext : DbContext
     {
         private readonly SqliteConnection _connection;

--- a/src/Likvido.Test.Api/DbFixtures/Sqlite/SqliteContextFixture.cs
+++ b/src/Likvido.Test.Api/DbFixtures/Sqlite/SqliteContextFixture.cs
@@ -5,6 +5,11 @@ using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace Likvido.Test.Api.Sqlite
 {
+    public abstract class SqliteContextFixture<TContext> : SqliteContextFixture<TContext, TContext>
+        where TContext : DbContext
+    {
+    }
+
     public abstract class SqliteContextFixture<TDesignContext, TRuntimeContext> : ContextFixtureBase<TDesignContext, TRuntimeContext>
         where TDesignContext : DbContext
         where TRuntimeContext : DbContext

--- a/src/Likvido.Test.Api/DbFixtures/Sqlite/SqliteContextFixture.cs
+++ b/src/Likvido.Test.Api/DbFixtures/Sqlite/SqliteContextFixture.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace Likvido.Test.Api.Sqlite
+{
+    public abstract class SqliteContextFixture<TDesignContext, TRuntimeContext> : ContextFixtureBase<TDesignContext, TRuntimeContext>
+        where TDesignContext : TRuntimeContext
+        where TRuntimeContext : DbContext
+    {
+        private readonly SqliteConnection _connection;
+
+        protected SqliteContextFixture()
+        {
+            _connection = new SqliteConnection(new SqliteConnectionStringBuilder { DataSource = ":memory:" }.ToString());
+            _connection.Open();
+        }
+
+        public override TRuntimeContext GenerateRuntimeContext()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder<TRuntimeContext>();
+            var options = optionsBuilder
+                .UseSqlite(_connection)
+                .Options;
+            return (TRuntimeContext)Activator.CreateInstance(typeof(TRuntimeContext), options)!;
+        }
+
+        public override TDesignContext GenerateDesignContext()
+        {
+            var optionsBuilder = new DbContextOptionsBuilder<TDesignContext>();
+            var options = optionsBuilder
+                .UseSqlite(_connection)
+                .ReplaceService<IMigrationsSqlGenerator, SqliteMigrationGenerator>()
+                .Options;
+            return (TDesignContext)Activator.CreateInstance(typeof(TDesignContext), options)!;
+        }
+
+        public override void ExecuteMigration(TDesignContext context)
+        {
+            context.Database.EnsureCreated();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _connection?.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Likvido.Test.Api/DbFixtures/Sqlite/SqliteDatabaseFixture.cs
+++ b/src/Likvido.Test.Api/DbFixtures/Sqlite/SqliteDatabaseFixture.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace Likvido.Test.Api.Sqlite
+{
+    public class SqliteDatabaseFixture<TDesignContext, TRuntimeContext> : DatabaseFixture<TDesignContext, TRuntimeContext>
+        where TDesignContext : TRuntimeContext
+        where TRuntimeContext : DbContext
+    {
+        private readonly ContextFixtureBase<TDesignContext, TRuntimeContext> _contextFixture;
+
+        public SqliteDatabaseFixture(
+            SqliteContextFixture<TDesignContext, TRuntimeContext> contextFixture)
+        {
+            _contextFixture = contextFixture;
+        }
+
+        public override ContextFixtureBase<TDesignContext, TRuntimeContext> ContextFixture => _contextFixture;
+
+        public override DatabaseFixtureType DbType => DatabaseFixtureType.Sqlite;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _contextFixture?.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/Likvido.Test.Api/DbFixtures/Sqlite/SqliteDatabaseFixture.cs
+++ b/src/Likvido.Test.Api/DbFixtures/Sqlite/SqliteDatabaseFixture.cs
@@ -2,6 +2,16 @@
 
 namespace Likvido.Test.Api.Sqlite
 {
+    public class SqliteDatabaseFixture<TContext> : SqliteDatabaseFixture<TContext, TContext>
+        where TContext : DbContext
+    {
+        public SqliteDatabaseFixture(
+            SqliteContextFixture<TContext> contextFixture)
+            : base(contextFixture)
+        {
+        }
+    }
+
     public class SqliteDatabaseFixture<TDesignContext, TRuntimeContext> : DatabaseFixture<TDesignContext, TRuntimeContext>
         where TDesignContext : DbContext
         where TRuntimeContext : DbContext

--- a/src/Likvido.Test.Api/DbFixtures/Sqlite/SqliteDatabaseFixture.cs
+++ b/src/Likvido.Test.Api/DbFixtures/Sqlite/SqliteDatabaseFixture.cs
@@ -3,7 +3,7 @@
 namespace Likvido.Test.Api.Sqlite
 {
     public class SqliteDatabaseFixture<TDesignContext, TRuntimeContext> : DatabaseFixture<TDesignContext, TRuntimeContext>
-        where TDesignContext : TRuntimeContext
+        where TDesignContext : DbContext
         where TRuntimeContext : DbContext
     {
         private readonly ContextFixtureBase<TDesignContext, TRuntimeContext> _contextFixture;

--- a/src/Likvido.Test.Api/DbFixtures/Sqlite/SqliteMigrationGenerator.cs
+++ b/src/Likvido.Test.Api/DbFixtures/Sqlite/SqliteMigrationGenerator.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal;
+
+namespace Likvido.Test.Api.Sqlite
+{
+    internal class SqliteMigrationGenerator : MigrationsSqlGenerator
+    {
+        private readonly IDictionary<string, string> Replacements = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase)
+        {
+            ["newsequentialid()"] = "",
+            ["getdate()"] = "CURRENT_TIMESTAMP",
+            ["getutcdate()"] = "CURRENT_TIMESTAMP"
+        };
+
+        public SqliteMigrationGenerator(MigrationsSqlGeneratorDependencies dependencies) : base(dependencies)
+        {
+        }
+
+        protected override void DefaultValue(object defaultValue, string defaultValueSql, string columnType, MigrationCommandListBuilder builder)
+        {
+            if (defaultValueSql != null) // I assume you only want to adapt specific values rather than whole type
+            {
+                if (Dependencies.SqlGenerationHelper is SqliteSqlGenerationHelper
+                    && Replacements.TryGetValue(defaultValueSql, out var replacement))
+                {
+                    if (string.IsNullOrEmpty(replacement))
+                    {
+                        return;
+                    }
+                    builder
+                        .Append(" DEFAULT (")
+                        .Append(replacement)
+                        .Append(")");
+                    return;
+                }
+            }
+            //fall back to default implementation
+            base.DefaultValue(defaultValue, defaultValueSql, columnType, builder);
+        }
+    }
+}

--- a/src/Likvido.Test.Api/DbFixtures/Sqlite/SqliteMigrationGenerator.cs
+++ b/src/Likvido.Test.Api/DbFixtures/Sqlite/SqliteMigrationGenerator.cs
@@ -5,9 +5,11 @@ using Microsoft.EntityFrameworkCore.Sqlite.Storage.Internal;
 
 namespace Likvido.Test.Api.Sqlite
 {
+#pragma warning disable CA1812 // SqliteMigrationGenerator is an internal class that is apparently never instantiated.
     internal class SqliteMigrationGenerator : MigrationsSqlGenerator
+#pragma warning restore CA1812 // SqliteMigrationGenerator is an internal class that is apparently never instantiated.
     {
-        private readonly IDictionary<string, string> Replacements = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase)
+        private readonly IDictionary<string, string> _replacements = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase)
         {
             ["newsequentialid()"] = "",
             ["getdate()"] = "CURRENT_TIMESTAMP",
@@ -20,21 +22,19 @@ namespace Likvido.Test.Api.Sqlite
 
         protected override void DefaultValue(object defaultValue, string defaultValueSql, string columnType, MigrationCommandListBuilder builder)
         {
-            if (defaultValueSql != null) // I assume you only want to adapt specific values rather than whole type
+            if (defaultValueSql != null &&
+                Dependencies.SqlGenerationHelper is SqliteSqlGenerationHelper &&
+                _replacements.TryGetValue(defaultValueSql, out var replacement)) // I assume you only want to adapt specific values rather than whole type
             {
-                if (Dependencies.SqlGenerationHelper is SqliteSqlGenerationHelper
-                    && Replacements.TryGetValue(defaultValueSql, out var replacement))
+                if (string.IsNullOrEmpty(replacement))
                 {
-                    if (string.IsNullOrEmpty(replacement))
-                    {
-                        return;
-                    }
-                    builder
-                        .Append(" DEFAULT (")
-                        .Append(replacement)
-                        .Append(")");
                     return;
                 }
+                builder
+                    .Append(" DEFAULT (")
+                    .Append(replacement)
+                    .Append(")");
+                return;
             }
             //fall back to default implementation
             base.DefaultValue(defaultValue, defaultValueSql, columnType, builder);

--- a/src/Likvido.Test.Api/HttpClientFactory/HttpClientFactory.cs
+++ b/src/Likvido.Test.Api/HttpClientFactory/HttpClientFactory.cs
@@ -35,11 +35,11 @@ namespace Likvido.Test.Api
                 return namedHttpClient;
             }
 
-            if (_options.ConfigureNamedHttpClients != null &&
+            if (_options?.ConfigureNamedHttpClients != null &&
                 _options.ConfigureNamedHttpClients.TryGetValue(name, out var httpClientConfig))
             {
                 var httpClient = _factory.CreateClient();
-                httpClientConfig.Invoke(_factory.Services, httpClient);
+                httpClientConfig?.Invoke(_factory.Services, httpClient);
                 _namedHttpClients[name] = httpClient;
                 return httpClient;
             }

--- a/src/Likvido.Test.Api/HttpClientFactory/HttpClientFactory.cs
+++ b/src/Likvido.Test.Api/HttpClientFactory/HttpClientFactory.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Likvido.Test.Api
@@ -19,7 +18,6 @@ namespace Likvido.Test.Api
         private readonly WebApplicationFactory<TStartup> _factory;
         private readonly Dictionary<string, HttpClient> _namedHttpClients = new();
 
-        private IConfiguration? _configuration;
         private HttpClient? _httpClient;
 
         public HttpClientFactory(HttpClientFactoryOptions options)
@@ -27,8 +25,6 @@ namespace Likvido.Test.Api
             _options = options;
             _factory = CreateWebAppFactory();
         }
-
-        public IConfiguration Configuration => _configuration ??= _factory.Services.GetRequiredService<IConfiguration>();
 
         public HttpClient HttpClient => _httpClient ??= _factory.CreateClient();
 
@@ -43,7 +39,7 @@ namespace Likvido.Test.Api
                 _options.ConfigureNamedHttpClients.TryGetValue(name, out var httpClientConfig))
             {
                 var httpClient = _factory.CreateClient();
-                httpClientConfig.Invoke(httpClient, Configuration);
+                httpClientConfig.Invoke(_factory.Services, httpClient);
                 _namedHttpClients[name] = httpClient;
                 return httpClient;
             }

--- a/src/Likvido.Test.Api/HttpClientFactory/HttpClientFactory.cs
+++ b/src/Likvido.Test.Api/HttpClientFactory/HttpClientFactory.cs
@@ -16,14 +16,14 @@ namespace Likvido.Test.Api
     public class HttpClientFactory<TStartup> : IDisposable
         where TStartup : class
     {
-        private readonly HttpClientFactoryBuilderOptions _options;
+        private readonly HttpClientFactoryOptions _options;
         private readonly WebApplicationFactory<TStartup> _factory;
         private readonly Dictionary<string, HttpClient> _namedHttpClients = new();
-        
+
         private IConfiguration? _configuration;
         private HttpClient? _httpClient;
-        
-        internal HttpClientFactory(HttpClientFactoryBuilderOptions options)
+
+        public HttpClientFactory(HttpClientFactoryOptions options)
         {
             _options = options;
             _factory = CreateWebAppFactory();
@@ -59,7 +59,9 @@ namespace Likvido.Test.Api
             var projectDir = Directory.GetCurrentDirectory();
             var configPath = Path.Combine(projectDir, "appsettings.json");
 
+#pragma warning disable CA2000 // Dispose objects before losing scope
             return new WebApplicationFactory<TStartup>()
+#pragma warning restore CA2000 // Dispose objects before losing scope
                 .WithWebHostBuilder(builder =>
                 {
                     builder.ConfigureAppConfiguration((context, conf) =>

--- a/src/Likvido.Test.Api/HttpClientFactory/HttpClientFactory.cs
+++ b/src/Likvido.Test.Api/HttpClientFactory/HttpClientFactory.cs
@@ -12,7 +12,6 @@ using Microsoft.Extensions.Logging;
 
 namespace Likvido.Test.Api
 {
-
     public class HttpClientFactory<TStartup> : IDisposable
         where TStartup : class
     {

--- a/src/Likvido.Test.Api/HttpClientFactory/HttpClientFactory.cs
+++ b/src/Likvido.Test.Api/HttpClientFactory/HttpClientFactory.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Likvido.Test.Api
+{
+
+    public class HttpClientFactory<TStartup> : IDisposable
+        where TStartup : class
+    {
+        private readonly HttpClientFactoryBuilderOptions _options;
+        private readonly WebApplicationFactory<TStartup> _factory;
+        private readonly Dictionary<string, HttpClient> _namedHttpClients = new();
+        
+        private IConfiguration? _configuration;
+        private HttpClient? _httpClient;
+        
+        internal HttpClientFactory(HttpClientFactoryBuilderOptions options)
+        {
+            _options = options;
+            _factory = CreateWebAppFactory();
+        }
+
+        public IConfiguration Configuration => _configuration ??= _factory.Services.GetRequiredService<IConfiguration>();
+
+        public HttpClient HttpClient => _httpClient ??= _factory.CreateClient();
+
+        public HttpClient GetNamedHttpClient(string name)
+        {
+            if (_namedHttpClients.TryGetValue(name, out var namedHttpClient))
+            {
+                return namedHttpClient;
+            }
+
+            if (_options.ConfigureNamedHttpClients != null &&
+                _options.ConfigureNamedHttpClients.TryGetValue(name, out var httpClientConfig))
+            {
+                var httpClient = _factory.CreateClient();
+                httpClientConfig.Invoke(httpClient, Configuration);
+                _namedHttpClients[name] = httpClient;
+                return httpClient;
+            }
+            else
+            {
+                throw new InvalidOperationException($"HttpClient {name} is not configured.");
+            }
+        }
+
+        private WebApplicationFactory<TStartup> CreateWebAppFactory()
+        {
+            var projectDir = Directory.GetCurrentDirectory();
+            var configPath = Path.Combine(projectDir, "appsettings.json");
+
+            return new WebApplicationFactory<TStartup>()
+                .WithWebHostBuilder(builder =>
+                {
+                    builder.ConfigureAppConfiguration((context, conf) =>
+                    {
+                        conf.AddJsonFile(configPath);
+                    });
+
+                    builder.ConfigureLogging(logging =>
+                    {
+                        logging.ClearProviders(); // Remove loggers
+                    });
+
+                    builder.ConfigureTestServices((s) =>
+                    {
+                        _options.ConfigureServices?.Invoke(s);
+                    });
+                });
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposing)
+            {
+                return;
+            }
+
+            _factory?.Dispose();
+            _httpClient?.Dispose();
+
+            var httpClients = _namedHttpClients.Values.ToList();
+            _namedHttpClients.Clear();
+            httpClients.ForEach(x => x.Dispose());
+        }
+    }
+}

--- a/src/Likvido.Test.Api/HttpClientFactory/HttpClientFactoryBuilder.cs
+++ b/src/Likvido.Test.Api/HttpClientFactory/HttpClientFactoryBuilder.cs
@@ -1,0 +1,9 @@
+﻿namespace Likvido.Test.Api
+{
+    public static class HttpClientFactoryBuilder<TStartup>
+        where TStartup : class
+    {
+        public static HttpClientFactory<TStartup> Build(HttpClientFactoryBuilderOptions options) =>
+            new(options);
+    }
+}

--- a/src/Likvido.Test.Api/HttpClientFactory/HttpClientFactoryBuilder.cs
+++ b/src/Likvido.Test.Api/HttpClientFactory/HttpClientFactoryBuilder.cs
@@ -1,9 +1,0 @@
-﻿namespace Likvido.Test.Api
-{
-    public static class HttpClientFactoryBuilder<TStartup>
-        where TStartup : class
-    {
-        public static HttpClientFactory<TStartup> Build(HttpClientFactoryBuilderOptions options) =>
-            new(options);
-    }
-}

--- a/src/Likvido.Test.Api/HttpClientFactory/HttpClientFactoryBuilderOptions.cs
+++ b/src/Likvido.Test.Api/HttpClientFactory/HttpClientFactoryBuilderOptions.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Likvido.Test.Api
+{
+    public class HttpClientFactoryBuilderOptions
+    {
+        public Action<IServiceCollection>? ConfigureServices { get; set; }
+        public Dictionary<string, Action<HttpClient, IConfiguration>>? ConfigureNamedHttpClients { get; set; }
+    }
+}

--- a/src/Likvido.Test.Api/HttpClientFactory/HttpClientFactoryOptions.cs
+++ b/src/Likvido.Test.Api/HttpClientFactory/HttpClientFactoryOptions.cs
@@ -6,9 +6,11 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Likvido.Test.Api
 {
-    public class HttpClientFactoryBuilderOptions
+    public class HttpClientFactoryOptions
     {
         public Action<IServiceCollection>? ConfigureServices { get; set; }
+#pragma warning disable CA2227 // Collection properties should be read only
         public Dictionary<string, Action<HttpClient, IConfiguration>>? ConfigureNamedHttpClients { get; set; }
+#pragma warning restore CA2227 // Collection properties should be read only
     }
 }

--- a/src/Likvido.Test.Api/HttpClientFactory/HttpClientFactoryOptions.cs
+++ b/src/Likvido.Test.Api/HttpClientFactory/HttpClientFactoryOptions.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net.Http;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Likvido.Test.Api
@@ -10,7 +9,7 @@ namespace Likvido.Test.Api
     {
         public Action<IServiceCollection>? ConfigureServices { get; set; }
 #pragma warning disable CA2227 // Collection properties should be read only
-        public Dictionary<string, Action<HttpClient, IConfiguration>>? ConfigureNamedHttpClients { get; set; }
+        public Dictionary<string, Action<IServiceProvider, HttpClient>>? ConfigureNamedHttpClients { get; set; }
 #pragma warning restore CA2227 // Collection properties should be read only
     }
 }

--- a/src/Likvido.Test.Api/Likvido.Test.Api.csproj
+++ b/src/Likvido.Test.Api/Likvido.Test.Api.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  
+  <Import Project="$(ProjectDir)../version.props" />
+  
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.10" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+  </ItemGroup>
+
+</Project>

--- a/src/Likvido.Test.Api/Likvido.Test.Api.csproj
+++ b/src/Likvido.Test.Api/Likvido.Test.Api.csproj
@@ -1,11 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
-  
   <Import Project="$(ProjectDir)../version.props" />
+  <Import Project="$(ProjectDir)../shared.props" />
   
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.10" />

--- a/src/shared.props
+++ b/src/shared.props
@@ -1,0 +1,22 @@
+<Project>
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
+    <!--https://github.com/dotnet/roslyn/issues/41640-->
+    <DocumentationFile>bin\$(MSBuildProjectName).xml</DocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <WarningsAsErrors />
+    <!--https://github.com/dotnet/roslyn/issues/41640-->
+    <DocumentationFile>bin\$(MSBuildProjectName).xml</DocumentationFile>
+  </PropertyGroup>
+</Project>

--- a/src/version.props
+++ b/src/version.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <Version>1.0.0</Version>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
https://github.com/Likvido/Likvido.App/issues/10075

Extracted shared code for API tests:
* Taken most of the implementation from `Likvido.WebAppApi.Tests`
* Added option for separate design/runtime contexts - migrate/testdata/cleanup on design context, execute tests on runtime context
* Sqlite db fixture (some changes from `Likvido.Payables.Api.Tests`)
* In usage can inherit from `ConfigurableTestFixture` and define mocks (auto configured) and named http clients (e.g. auth with api key)

