### PR TITLE
Disallow AllowAutoRedirect for HttpClients

### DIFF
--- a/src/Likvido.Test.Api/HttpClientFactory/HttpClientFactory.cs
+++ b/src/Likvido.Test.Api/HttpClientFactory/HttpClientFactory.cs
@@ -26,7 +26,7 @@ namespace Likvido.Test.Api
             _factory = CreateWebAppFactory();
         }
 
-        public HttpClient HttpClient => _httpClient ??= _factory.CreateClient();
+        public HttpClient HttpClient => _httpClient ??= CreateClient();
 
         public HttpClient GetNamedHttpClient(string name)
         {
@@ -38,7 +38,7 @@ namespace Likvido.Test.Api
             if (_options?.ConfigureNamedHttpClients != null &&
                 _options.ConfigureNamedHttpClients.TryGetValue(name, out var httpClientConfig))
             {
-                var httpClient = _factory.CreateClient();
+                var httpClient = CreateClient();
                 httpClientConfig?.Invoke(_factory.Services, httpClient);
                 _namedHttpClients[name] = httpClient;
                 return httpClient;
@@ -74,6 +74,14 @@ namespace Likvido.Test.Api
                         _options.ConfigureServices?.Invoke(s);
                     });
                 });
+        }
+
+        private HttpClient CreateClient()
+        {
+            return _factory.CreateClient(new WebApplicationFactoryClientOptions
+            {
+                AllowAutoRedirect = false
+            });
         }
 
         public void Dispose()

--- a/src/version.props
+++ b/src/version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Hi @raskhodchikov! I think we have a minor issue with this package.
We have a scenario in BankReading repo where we do `return Redirect(result.RedirectUri.ToString());` from controller.
Current code doesn't allow to assert `302` status in our tests and I can not check for a redirection URL as well.
I quickly googled and found this SO thread: https://stackoverflow.com/a/14732388/2087823
I tested it quickly in web app api by returning a redirect from one of endpoints:
![image](https://user-images.githubusercontent.com/4623993/147405577-dd74ec79-2d53-4fba-a5ab-7a939c1cdd45.png)

It seems to cover the redirect scenario. Do you think we can merge this one?
